### PR TITLE
[FIX] Adding some session validation.

### DIFF
--- a/code/services/PDFRenditionService.php
+++ b/code/services/PDFRenditionService.php
@@ -217,7 +217,13 @@ class PDFRenditionService {
 	 * 				The filename of the output file
 	 */
 	public function renderPage($page, $action='', $outputTo = null, $outname='') {
-		$link = Director::makeRelative($page->Link($action));
+		// Allow the ability to pass through a customised link.
+		if (Controller::has_curr() && Controller::curr()->getRequest()->getVar('link')) {
+			$link = urldecode(Controller::curr()->getRequest()->getVar('link'));
+		}
+		else {
+			$link = Director::makeRelative($page->Link($action));
+		}
 		return $this->renderUrl($link, $outputTo, $outname);
 	}
 

--- a/code/services/PDFRenditionService.php
+++ b/code/services/PDFRenditionService.php
@@ -197,7 +197,7 @@ class PDFRenditionService {
 		}
 		// convert the URL to content
 		// do a 'test' request, making sure to keep the current session active
-		$response = Director::test($url, null, new Session($_SESSION));
+		$response = Director::test($url, null, isset($_SESSION) ? new Session($_SESSION) : null);
 		if ($response->getStatusCode() == 200) {
 			return $this->render($response->getBody(), $outputTo, $outname);
 		} else {


### PR DESCRIPTION
- There may not be a session that has actually been started.
- This is currently an issue for a client project when attempting to render a PDF.

# [FIX] Allow the ability to pass through a customised link for PDF rendition.

- This means you can now pass through GET parameters for the page.
- While there may be other possible solutions here, this was the quickest and most flexible solution.